### PR TITLE
refactor (#139): upload file api

### DIFF
--- a/data/src/main/kotlin/io/timemates/backend/data/files/FilesRepository.kt
+++ b/data/src/main/kotlin/io/timemates/backend/data/files/FilesRepository.kt
@@ -1,20 +1,33 @@
 package io.timemates.backend.data.files
 
+import com.timemates.backend.time.UnixTime
+import io.timemates.backend.data.files.datasource.FileEntityMapper
 import io.timemates.backend.data.files.datasource.LocalFilesDataSource
 import io.timemates.backend.data.files.datasource.PostgresqlFilesDataSource
 import io.timemates.backend.files.types.File
+import io.timemates.backend.files.types.FileType
 import io.timemates.backend.files.types.value.FileId
 import kotlinx.coroutines.flow.Flow
 import java.io.InputStream
+import kotlin.io.path.pathString
 import io.timemates.backend.files.repositories.FilesRepository as FilesRepositoryContract
 
 
 class FilesRepository(
     private val localFilesDataSource: LocalFilesDataSource,
     private val postgresqlFilesDataSource: PostgresqlFilesDataSource,
+    private val mapper: FileEntityMapper,
 ) : FilesRepositoryContract {
-    override suspend fun save(fileId: FileId, input: Flow<ByteArray>) {
-        localFilesDataSource.save(fileId.string, LocalFilesDataSource.FileType.IMAGE, input)
+    override suspend fun save(fileId: FileId, fileType: FileType, input: Flow<ByteArray>, creationTime: UnixTime) {
+        postgresqlFilesDataSource.createFile(
+            fileId = fileId.string,
+            fileName = fileId.string,
+            fileType = mapper.domainTypeToDbType(fileType),
+            filePath = localFilesDataSource.localFilesPath.pathString,
+            creationTime = creationTime.inMilliseconds,
+        )
+
+        localFilesDataSource.save(fileId.string, mapper.domainTypeToLocalFilesType(fileType), input)
     }
 
     override suspend fun retrieve(file: File): InputStream? {

--- a/data/src/main/kotlin/io/timemates/backend/data/files/datasource/FileEntityMapper.kt
+++ b/data/src/main/kotlin/io/timemates/backend/data/files/datasource/FileEntityMapper.kt
@@ -5,6 +5,7 @@ import io.timemates.backend.data.files.datasource.PostgresqlFilesDataSource.File
 import io.timemates.backend.files.types.value.FileId
 import org.jetbrains.exposed.sql.ResultRow
 import io.timemates.backend.files.types.File as DomainFile
+import io.timemates.backend.files.types.FileType as DomainFileType
 
 
 class FileEntityMapper {
@@ -13,6 +14,18 @@ class FileEntityMapper {
             FileType.IMAGE -> DomainFile.Image(
                 FileId.createOrThrow(file.fileId),
             )
+        }
+    }
+
+    fun domainTypeToLocalFilesType(fileType: DomainFileType): LocalFilesDataSource.FileType {
+        return when (fileType) {
+            DomainFileType.IMAGE -> LocalFilesDataSource.FileType.IMAGE
+        }
+    }
+
+    fun domainTypeToDbType(fileType: DomainFileType): FileType {
+        return when (fileType) {
+            DomainFileType.IMAGE -> FileType.IMAGE
         }
     }
 

--- a/data/src/main/kotlin/io/timemates/backend/data/files/datasource/LocalFilesDataSource.kt
+++ b/data/src/main/kotlin/io/timemates/backend/data/files/datasource/LocalFilesDataSource.kt
@@ -9,7 +9,7 @@ import java.io.InputStream
 import java.nio.file.Path
 import kotlin.io.path.*
 
-class LocalFilesDataSource(private val localFilesPath: Path) {
+class LocalFilesDataSource(internal val localFilesPath: Path) {
 
     enum class FileType {
         IMAGE,

--- a/domain/src/main/kotlin/io/timemates/backend/files/repositories/FilesRepository.kt
+++ b/domain/src/main/kotlin/io/timemates/backend/files/repositories/FilesRepository.kt
@@ -1,12 +1,14 @@
 package io.timemates.backend.files.repositories
 
+import com.timemates.backend.time.UnixTime
 import io.timemates.backend.files.types.File
+import io.timemates.backend.files.types.FileType
 import io.timemates.backend.files.types.value.FileId
 import kotlinx.coroutines.flow.Flow
 import java.io.InputStream
 
 interface FilesRepository {
-    suspend fun save(fileId: FileId, input: Flow<ByteArray>)
+    suspend fun save(fileId: FileId, fileType: FileType, input: Flow<ByteArray>, creationTime: UnixTime)
     suspend fun retrieve(file: File): InputStream?
     suspend fun remove(fileId: FileId)
 }

--- a/domain/src/main/kotlin/io/timemates/backend/files/types/FileType.kt
+++ b/domain/src/main/kotlin/io/timemates/backend/files/types/FileType.kt
@@ -1,0 +1,5 @@
+package io.timemates.backend.files.types
+
+enum class FileType {
+    IMAGE,
+}

--- a/infrastructure/application/src/main/kotlin/io/timemates/backend/application/dependencies/FilesModule.kt
+++ b/infrastructure/application/src/main/kotlin/io/timemates/backend/application/dependencies/FilesModule.kt
@@ -6,6 +6,7 @@ import io.timemates.backend.data.files.datasource.PostgresqlFilesDataSource
 import io.timemates.backend.files.repositories.FilesRepository
 import io.timemates.backend.files.usecases.GetImageUseCase
 import io.timemates.backend.files.usecases.UploadFileUseCase
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.net.URI
@@ -24,12 +25,7 @@ val FilesModule = module {
     single {
         FileEntityMapper()
     }
-    single<FilesRepository> {
-        LocalFilesRepository(
-            localFilesDataSource = get(),
-            postgresqlFilesDataSource = get()
-        )
-    }
+    singleOf(::LocalFilesRepository)
     single {
         GetImageUseCase(filesRepository = get())
     }

--- a/infrastructure/application/src/main/kotlin/io/timemates/backend/application/dependencies/FilesModule.kt
+++ b/infrastructure/application/src/main/kotlin/io/timemates/backend/application/dependencies/FilesModule.kt
@@ -19,29 +19,11 @@ val FilesModule = module {
     single {
         LocalFilesDataSource(Path.of(get<URI>(filesPathName)))
     }
-    single {
-        PostgresqlFilesDataSource(database = get(), mapper = get())
-    }
-    single {
-        FileEntityMapper()
-    }
+    singleOf(::PostgresqlFilesDataSource)
+    singleOf(::FileEntityMapper)
     singleOf(::LocalFilesRepository)
-    single {
-        GetImageUseCase(filesRepository = get())
-    }
-    single {
-        UploadFileUseCase(files = get(), randomProvider = get())
-    }
-
 
     // Use cases
-    single {
-        GetImageUseCase(filesRepository = get())
-    }
-    single {
-        UploadFileUseCase(
-            files = get(),
-            randomProvider = get()
-        )
-    }
+    singleOf(::GetImageUseCase)
+    singleOf(::UploadFileUseCase)
 }

--- a/infrastructure/services/src/main/kotlin/io/timemates/backend/services/files/FilesService.kt
+++ b/infrastructure/services/src/main/kotlin/io/timemates/backend/services/files/FilesService.kt
@@ -9,15 +9,16 @@ import io.timemates.api.files.requests.GetFileBytesRequestKt
 import io.timemates.api.files.requests.GetFileBytesRequestOuterClass.GetFileBytesRequest
 import io.timemates.api.files.requests.UploadFileRequestKt
 import io.timemates.api.files.requests.UploadFileRequestOuterClass
+import io.timemates.api.files.requests.UploadFileRequestOuterClass.UploadFileRequest.FileMetadata
+import io.timemates.api.files.requests.metadataOrNull
 import io.timemates.backend.coroutines.asFlow
 import io.timemates.backend.files.types.File
+import io.timemates.backend.files.types.FileType
 import io.timemates.backend.files.types.value.FileId
 import io.timemates.backend.files.usecases.GetImageUseCase
 import io.timemates.backend.files.usecases.UploadFileUseCase
 import io.timemates.backend.services.authorization.context.provideAuthorizationContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 
 class FilesService(
     private val getImageUseCase: GetImageUseCase,
@@ -42,7 +43,14 @@ class FilesService(
     override suspend fun uploadFile(
         requests: Flow<UploadFileRequestOuterClass.UploadFileRequest>,
     ): UploadFileRequestOuterClass.UploadFileRequest.Response = provideAuthorizationContext {
-        when (val result = uploadFileUseCase.execute(requests.map { it.chunk.toByteArray() })) {
+        val fileMetadata = requests.first().metadataOrNull
+            ?: throw StatusException(Status.INVALID_ARGUMENT.withDescription("No metadata provided"))
+        val fileBytes = requests.filter { it.hasChunk() }.map { it.chunk.toByteArray() }
+
+        if(fileMetadata.fileType == FileMetadata.FileType.BINARY)
+            throw StatusException(Status.UNIMPLEMENTED.withDescription("Binary file is unsupported"))
+
+        when (val result = uploadFileUseCase.execute(FileType.IMAGE, fileBytes)) {
             UploadFileUseCase.Result.Failure -> throw StatusException(Status.INTERNAL)
             is UploadFileUseCase.Result.Success -> UploadFileRequestKt.response {
                 fileId = result.fileId.string

--- a/infrastructure/services/src/main/proto/io/timemates/api/files/requests/UploadFileRequest.proto
+++ b/infrastructure/services/src/main/proto/io/timemates/api/files/requests/UploadFileRequest.proto
@@ -3,12 +3,29 @@ syntax = "proto3";
 option java_package = "io.timemates.api.files.requests";
 
 message UploadFileRequest {
-  /**
-   * Bytes of file included into given chunk.
-   */
-  bytes chunk = 1;
+  oneof request {
+    /**
+     * Should always be sent as first request.
+     * Should not be repeated.
+     */
+    FileMetadata metadata = 1;
+    /**
+     * Bytes of file included into given chunk.
+     */
+    bytes chunk = 2;
+  }
 
   message Response {
     string fileId = 1;
+  }
+
+  message FileMetadata {
+    FileType fileType = 1;
+    string fileName = 2;
+
+    enum FileType {
+      BINARY = 0; // unsupported by default
+      IMAGE = 1;
+    }
   }
 }


### PR DESCRIPTION
Refactored to next scheme:
```proto
message UploadFileRequest {
  oneof request {
    /**
     * Should always be sent as first request.
     * Should not be repeated.
     */
    FileMetadata metadata = 1;
    /**
     * Bytes of file included into given chunk.
     */
    bytes chunk = 2;
  }

  message Response {
    string fileId = 1;
  }

  message FileMetadata {
    FileType fileType = 1;
    string fileName = 2;

    enum FileType {
      BINARY = 0; // unsupported by default
      IMAGE = 1;
    }
  }
}
```

closes #139 